### PR TITLE
Add resilient storage fallbacks for login flow

### DIFF
--- a/js/storage-utils.js
+++ b/js/storage-utils.js
@@ -1,0 +1,203 @@
+(function(window) {
+    'use strict';
+
+    const memoryStore = new Map();
+    const COOKIE_PREFIX = 'site_auth_';
+    const DEFAULT_COOKIE_MAX_AGE = 2 * 60 * 60; // 2 hours
+
+    function storageAvailable(type) {
+        try {
+            const storage = window[type];
+            const testKey = '__storage_test__';
+            storage.setItem(testKey, '1');
+            storage.removeItem(testKey);
+            return true;
+        } catch (error) {
+            console.warn(`${type} is not available:`, error.message);
+            return false;
+        }
+    }
+
+    function setCookie(name, value, maxAgeSeconds) {
+        const encodedValue = encodeURIComponent(value);
+        const maxAge = typeof maxAgeSeconds === 'number' ? maxAgeSeconds : DEFAULT_COOKIE_MAX_AGE;
+        document.cookie = `${COOKIE_PREFIX}${name}=${encodedValue}; path=/; max-age=${maxAge}; SameSite=Lax`;
+    }
+
+    function getCookie(name) {
+        const cookieMatch = document.cookie.match(new RegExp(`(?:^|; )${COOKIE_PREFIX}${name}=([^;]*)`));
+        return cookieMatch ? decodeURIComponent(cookieMatch[1]) : null;
+    }
+
+    function removeCookie(name) {
+        document.cookie = `${COOKIE_PREFIX}${name}=; path=/; max-age=0; SameSite=Lax`;
+    }
+
+    const sessionEnabled = storageAvailable('sessionStorage');
+    const localEnabled = storageAvailable('localStorage');
+    const cookiesEnabled = navigator.cookieEnabled === undefined ? true : navigator.cookieEnabled;
+
+    function setItem(key, value, options = {}) {
+        const { maxAgeSeconds = DEFAULT_COOKIE_MAX_AGE, allowMemory = false } = options;
+
+        if (sessionEnabled) {
+            try {
+                window.sessionStorage.setItem(key, value);
+                return { success: true, mode: 'sessionStorage' };
+            } catch (error) {
+                console.warn('sessionStorage setItem failed:', error.message);
+            }
+        }
+
+        if (localEnabled) {
+            try {
+                window.localStorage.setItem(key, value);
+                return { success: true, mode: 'localStorage' };
+            } catch (error) {
+                console.warn('localStorage setItem failed:', error.message);
+            }
+        }
+
+        if (cookiesEnabled) {
+            try {
+                setCookie(key, value, maxAgeSeconds);
+                return { success: true, mode: 'cookie' };
+            } catch (error) {
+                console.warn('Cookie storage failed:', error.message);
+            }
+        }
+
+        if (allowMemory) {
+            memoryStore.set(key, value);
+            return { success: true, mode: 'memory' };
+        }
+
+        return { success: false, mode: 'none' };
+    }
+
+    function getItem(key) {
+        if (sessionEnabled) {
+            try {
+                const value = window.sessionStorage.getItem(key);
+                if (value !== null) {
+                    return value;
+                }
+            } catch (error) {
+                console.warn('sessionStorage getItem failed:', error.message);
+            }
+        }
+
+        if (localEnabled) {
+            try {
+                const value = window.localStorage.getItem(key);
+                if (value !== null) {
+                    return value;
+                }
+            } catch (error) {
+                console.warn('localStorage getItem failed:', error.message);
+            }
+        }
+
+        if (cookiesEnabled) {
+            try {
+                const cookieValue = getCookie(key);
+                if (cookieValue !== null) {
+                    return cookieValue;
+                }
+            } catch (error) {
+                console.warn('Cookie retrieval failed:', error.message);
+            }
+        }
+
+        if (memoryStore.has(key)) {
+            return memoryStore.get(key);
+        }
+
+        return null;
+    }
+
+    function removeItem(key) {
+        let removed = false;
+
+        if (sessionEnabled) {
+            try {
+                window.sessionStorage.removeItem(key);
+                removed = true;
+            } catch (error) {
+                console.warn('sessionStorage removeItem failed:', error.message);
+            }
+        }
+
+        if (localEnabled) {
+            try {
+                window.localStorage.removeItem(key);
+                removed = true;
+            } catch (error) {
+                console.warn('localStorage removeItem failed:', error.message);
+            }
+        }
+
+        if (cookiesEnabled) {
+            try {
+                removeCookie(key);
+                removed = true;
+            } catch (error) {
+                console.warn('Cookie removal failed:', error.message);
+            }
+        }
+
+        if (memoryStore.has(key)) {
+            memoryStore.delete(key);
+            removed = true;
+        }
+
+        return removed;
+    }
+
+    function setJSON(key, value, options = {}) {
+        try {
+            return setItem(key, JSON.stringify(value), options);
+        } catch (error) {
+            console.warn('Failed to serialize JSON for key', key, error.message);
+            return { success: false, mode: 'none' };
+        }
+    }
+
+    function getJSON(key, defaultValue = null) {
+        const raw = getItem(key);
+        if (!raw) {
+            return defaultValue;
+        }
+
+        try {
+            return JSON.parse(raw);
+        } catch (error) {
+            console.warn('Failed to parse JSON for key', key, error.message);
+            return defaultValue;
+        }
+    }
+
+    function clearKeys(keys) {
+        keys.forEach(key => removeItem(key));
+    }
+
+    function getStatus() {
+        return {
+            sessionEnabled,
+            localEnabled,
+            cookiesEnabled,
+            memoryFallbackActive: memoryStore.size > 0
+        };
+    }
+
+    window.StorageUtils = {
+        setItem,
+        getItem,
+        removeItem,
+        setJSON,
+        getJSON,
+        clearKeys,
+        getStatus,
+        COOKIE_PREFIX
+    };
+})(window);

--- a/login.html
+++ b/login.html
@@ -189,6 +189,7 @@
         <p>&copy; 2025 My First Website</p>
     </footer>
 
+    <script src="js/storage-utils.js"></script>
     <script src="js/script.js"></script>
     <script>
         /*
@@ -223,9 +224,26 @@
         */
 
         document.addEventListener('DOMContentLoaded', function() {
+            if (!window.StorageUtils) {
+                console.error('Storage utilities failed to load. Authentication cannot continue.');
+                return;
+            }
+
+            const storageStatus = StorageUtils.getStatus();
+            const SESSION_MAX_AGE_SECONDS = 2 * 60 * 60; // 2 hours
+            const rateLimitKey = 'loginAttempts';
+
             // Security enhancement: Rate limiting for brute force protection
             const MAX_LOGIN_ATTEMPTS = 5;
             const LOCKOUT_DURATION = 15 * 60 * 1000; // 15 minutes
+
+            if (!storageStatus.sessionEnabled) {
+                console.warn('Session storage is unavailable. Falling back to less secure storage.');
+            }
+
+            if (!storageStatus.sessionEnabled && !storageStatus.localEnabled && !storageStatus.cookiesEnabled) {
+                console.error('No available storage mechanisms. Login functionality will be disabled.');
+            }
             
             // Simple hash function for session tokens (client-side only)
             function simpleHash(str) {
@@ -248,28 +266,34 @@
 
             // Check rate limiting
             function checkRateLimit() {
-                const attempts = JSON.parse(localStorage.getItem('loginAttempts') || '[]');
+                const attempts = StorageUtils.getJSON(rateLimitKey, []);
                 const now = Date.now();
-                
+
                 // Remove old attempts (older than lockout duration)
                 const recentAttempts = attempts.filter(attempt => now - attempt < LOCKOUT_DURATION);
-                localStorage.setItem('loginAttempts', JSON.stringify(recentAttempts));
-                
+                StorageUtils.setJSON(rateLimitKey, recentAttempts, {
+                    maxAgeSeconds: LOCKOUT_DURATION / 1000,
+                    allowMemory: true
+                });
+
                 return recentAttempts.length < MAX_LOGIN_ATTEMPTS;
             }
 
             // Record failed login attempt
             function recordFailedAttempt() {
-                const attempts = JSON.parse(localStorage.getItem('loginAttempts') || '[]');
+                const attempts = StorageUtils.getJSON(rateLimitKey, []);
                 attempts.push(Date.now());
-                localStorage.setItem('loginAttempts', JSON.stringify(attempts));
+                StorageUtils.setJSON(rateLimitKey, attempts, {
+                    maxAgeSeconds: LOCKOUT_DURATION / 1000,
+                    allowMemory: true
+                });
             }
 
             // Get remaining lockout time
             function getRemainingLockoutTime() {
-                const attempts = JSON.parse(localStorage.getItem('loginAttempts') || '[]');
+                const attempts = StorageUtils.getJSON(rateLimitKey, []);
                 if (attempts.length === 0) return 0;
-                
+
                 const oldestAttempt = Math.min(...attempts);
                 const lockoutEnd = oldestAttempt + LOCKOUT_DURATION;
                 const remaining = lockoutEnd - Date.now();
@@ -278,8 +302,8 @@
             }
 
             // Check if user is already authenticated with token validation
-            const authToken = sessionStorage.getItem('authToken');
-            const username = sessionStorage.getItem('username');
+            const authToken = StorageUtils.getItem('authToken');
+            const username = StorageUtils.getItem('username');
             if (authToken && username) {
                 console.log('User already authenticated, redirecting to private area...');
                 window.location.href = 'private.html';
@@ -290,6 +314,12 @@
             const loginButton = document.getElementById('login-button');
             const errorMessage = document.getElementById('error-message');
             const successMessage = document.getElementById('success-message');
+
+            if (!storageStatus.sessionEnabled && !storageStatus.localEnabled && !storageStatus.cookiesEnabled) {
+                showError('Login is currently unavailable because your browser is blocking all forms of storage. Please enable cookies or storage access and refresh the page.');
+                loginButton.disabled = true;
+                return;
+            }
 
             function showError(message) {
                 errorMessage.textContent = message;
@@ -337,7 +367,9 @@
                 }
 
                 const usernameValue = document.getElementById('username').value.trim();
-                const password = document.getElementById('password').value;
+                const passwordInput = document.getElementById('password');
+                const password = passwordInput.value.trim();
+                passwordInput.value = password;
 
                 // Input validation
                 if (!usernameValue || !password) {
@@ -375,17 +407,37 @@
                         const sessionToken = generateSessionToken(usernameValue);
                         
                         // Clear any failed attempts on successful login
-                        localStorage.removeItem('loginAttempts');
-                        
+                        StorageUtils.removeItem(rateLimitKey);
+
                         // Set authentication data with hashed token
-                        sessionStorage.setItem('authToken', sessionToken);
-                        sessionStorage.setItem('username', usernameValue);
-                        sessionStorage.setItem('loginTime', new Date().toISOString());
-                        
-                        // Legacy support - keep for backward compatibility
-                        sessionStorage.setItem('authenticated', 'true');
+                        const sessionOptions = {
+                            maxAgeSeconds: SESSION_MAX_AGE_SECONDS,
+                            allowMemory: false
+                        };
+
+                        const authResults = [
+                            StorageUtils.setItem('authToken', sessionToken, sessionOptions),
+                            StorageUtils.setItem('username', usernameValue, sessionOptions),
+                            StorageUtils.setItem('loginTime', new Date().toISOString(), sessionOptions),
+                            StorageUtils.setItem('authenticated', 'true', sessionOptions)
+                        ];
+
+                        const storageSuccess = authResults.every(result => result.success);
+
+                        if (!storageSuccess) {
+                            console.error('Failed to persist authentication data.');
+                            showError('Unable to complete login because your browser is blocking storage. Please enable cookies or storage access and try again.');
+                            loginButton.disabled = false;
+                            loginButton.textContent = 'Log In';
+                            return;
+                        }
 
                         showSuccess('Login successful! Redirecting to private area...');
+
+                        const usedFallback = authResults.some(result => result.mode === 'cookie');
+                        if (usedFallback) {
+                            console.warn('Authentication data stored using cookie fallback.');
+                        }
 
                         // Redirect to private area after a short delay
                         setTimeout(() => {
@@ -395,7 +447,7 @@
                         console.log('Login failed - invalid credentials');
                         recordFailedAttempt();
                         
-                        const attemptsLeft = MAX_LOGIN_ATTEMPTS - JSON.parse(localStorage.getItem('loginAttempts') || '[]').length;
+                        const attemptsLeft = MAX_LOGIN_ATTEMPTS - StorageUtils.getJSON(rateLimitKey, []).length;
                         if (attemptsLeft > 0) {
                             showError(`Invalid username or password. ${attemptsLeft} attempts remaining. Try demo/password or demo/aaa.`);
                         } else {

--- a/private.html
+++ b/private.html
@@ -60,16 +60,30 @@
         <p>&copy; 2025 My First Website</p>
     </footer>
 
+    <script src="js/storage-utils.js"></script>
     <script src="js/script.js"></script>
     <script>
         // Enhanced authentication check and logout functionality
         document.addEventListener('DOMContentLoaded', function() {
+            if (!window.StorageUtils) {
+                console.error('Storage utilities failed to load. Redirecting to login...');
+                window.location.href = 'login.html';
+                return;
+            }
+
+            const storageStatus = StorageUtils.getStatus();
+            if (!storageStatus.sessionEnabled) {
+                console.warn('Session storage unavailable on private page. Using fallback storage mechanisms.');
+            }
+
+            const SESSION_KEYS = ['authenticated', 'authToken', 'username', 'loginTime'];
+
             // Validate authentication token
             function validateAuthToken() {
-                const authToken = sessionStorage.getItem('authToken');
-                const username = sessionStorage.getItem('username');
-                const authenticated = sessionStorage.getItem('authenticated');
-                
+                const authToken = StorageUtils.getItem('authToken');
+                const username = StorageUtils.getItem('username');
+                const authenticated = StorageUtils.getItem('authenticated');
+
                 // Check if we have both new token-based auth and legacy auth
                 return (authToken && username) || (authenticated === 'true');
             }
@@ -80,7 +94,7 @@
             if (!validateAuthToken()) {
                 console.log('User not authenticated, redirecting to login...');
                 // Clear any potentially corrupted session data
-                sessionStorage.clear();
+                StorageUtils.clearKeys(SESSION_KEYS);
                 // Redirect to login page if not authenticated
                 window.location.href = 'login.html';
                 return;
@@ -89,7 +103,7 @@
             console.log('User authenticated, loading private area...');
 
             // Display username if available
-            const username = sessionStorage.getItem('username');
+            const username = StorageUtils.getItem('username');
             if (username) {
                 // Update welcome message to include username
                 const welcomeSection = document.querySelector('#private-content h2');
@@ -104,13 +118,10 @@
             if (logoutButton) {
                 logoutButton.addEventListener('click', function() {
                     console.log('Logout button clicked');
-                    
+
                     // Clear all authentication data
-                    sessionStorage.removeItem('authenticated');
-                    sessionStorage.removeItem('authToken');
-                    sessionStorage.removeItem('username');
-                    sessionStorage.removeItem('loginTime');
-                    
+                    StorageUtils.clearKeys(SESSION_KEYS);
+
                     // Optional: Also clear any rate limiting data on logout
                     // localStorage.removeItem('loginAttempts');
 
@@ -121,15 +132,15 @@
             }
 
             // Optional: Add session timeout (example: 2 hours)
-            const loginTime = sessionStorage.getItem('loginTime');
+            const loginTime = StorageUtils.getItem('loginTime');
             if (loginTime) {
                 const sessionDuration = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
                 const loginTimestamp = new Date(loginTime).getTime();
                 const currentTime = Date.now();
-                
+
                 if (currentTime - loginTimestamp > sessionDuration) {
                     console.log('Session expired, redirecting to login...');
-                    sessionStorage.clear();
+                    StorageUtils.clearKeys(SESSION_KEYS);
                     window.location.href = 'login.html';
                     return;
                 }


### PR DESCRIPTION
## Summary
- add a shared storage utility that falls back from session storage to local storage, cookies, or in-memory data
- update the login page to rely on the new storage helper, gracefully handle disabled storage, and trim trailing password whitespace
- switch the private area page to the shared helper so successful logins persist even when session storage is blocked

## Testing
- node tests/run-tests.js *(fails: Missing page: index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68f6ad865a408321a411e18ff47f779a