### PR TITLE
Add guard for touchmove handling without touches

### DIFF
--- a/react-website/src/components/ArrowVisualization.tsx
+++ b/react-website/src/components/ArrowVisualization.tsx
@@ -209,6 +209,10 @@ const ArrowVisualization: React.FC<ArrowVisualizationProps> = ({ title = 'Progre
     };
     
     const handleTouchMove = (e: TouchEvent) => {
+      if (!e.touches.length) {
+        return;
+      }
+
       const touch = e.touches[0];
       
       const rect = canvas.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- add a guard in the arrow visualization touch move handler to avoid reading touches when none are active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6b3992c2083218f5560cce54dd708