### PR TITLE
Move hangman emulator into documents sections

### DIFF
--- a/documents.html
+++ b/documents.html
@@ -26,60 +26,70 @@
             <p>Here you can find various documents and resources related to this website project.</p>
 
             <div class="document-list">
+                <h3>Site Meta Documents</h3>
                 <ul>
                     <li>
-                        <h3><a href="hypermodernity_essay.html">Hypermodernity and Technology: An Essay in Six Chapters</a></h3>
-                        <div class="date">January 2025</div>
-                        <div class="excerpt">
-                            An in-depth essay exploring the intersection of hypermodernity, technology, and contemporary society through six analytical chapters.
-                        </div>
-                    </li>
-                    <li>
-                        <h3><a href="https://github.com/idealase/idealase.github.io/blob/main/README.md" target="_blank" rel="noopener noreferrer">Project Documentation</a></h3>
+                        <h4><a href="https://github.com/idealase/idealase.github.io/blob/main/README.md" target="_blank" rel="noopener noreferrer">Project Documentation</a></h4>
                         <div class="date">Created: January 2025</div>
                         <div class="excerpt">
                             Main project documentation covering the website architecture, features, and development philosophy.
                         </div>
                     </li>
                     <li>
-                        <h3><a href="https://github.com/idealase/idealase.github.io/blob/main/react-website/README.md" target="_blank" rel="noopener noreferrer">React App Guide</a></h3>
+                        <h4><a href="https://github.com/idealase/idealase.github.io/blob/main/react-website/README.md" target="_blank" rel="noopener noreferrer">React App Guide</a></h4>
                         <div class="date">Updated: January 2025</div>
                         <div class="excerpt">
                             Technical reference for the modern React application including setup, features, and deployment.
                         </div>
                     </li>
                     <li>
-                        <h3><a href="https://github.com/idealase/idealase.github.io/actions" target="_blank" rel="noopener noreferrer">GitHub Actions</a></h3>
+                        <h4><a href="https://github.com/idealase/idealase.github.io/actions" target="_blank" rel="noopener noreferrer">GitHub Actions</a></h4>
                         <div class="date">Ongoing</div>
                         <div class="excerpt">
                             View the CI/CD pipeline, workflow runs, and deployment automation for this project.
                         </div>
                     </li>
                     <li>
-                        <h3><a href="https://github.com/idealase/idealase.github.io/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">Security Guidelines</a></h3>
+                        <h4><a href="https://github.com/idealase/idealase.github.io/blob/main/SECURITY.md" target="_blank" rel="noopener noreferrer">Security Guidelines</a></h4>
                         <div class="date">Updated: January 2025</div>
                         <div class="excerpt">
                             Comprehensive security documentation covering secret management, dependency security, and best practices.
                         </div>
                     </li>
                     <li>
-                        <h3><a href="https://github.com/idealase/idealase.github.io/issues" target="_blank" rel="noopener noreferrer">Repository Issues</a></h3>
+                        <h4><a href="https://github.com/idealase/idealase.github.io/issues" target="_blank" rel="noopener noreferrer">Repository Issues</a></h4>
                         <div class="date">Ongoing</div>
                         <div class="excerpt">
                             Browse open and closed issues, bug reports, and feature requests for the project.
                         </div>
                     </li>
                     <li>
-                        <h3><a href="https://github.com/idealase/idealase.github.io/pulls" target="_blank" rel="noopener noreferrer">Pull Requests</a></h3>
+                        <h4><a href="https://github.com/idealase/idealase.github.io/pulls" target="_blank" rel="noopener noreferrer">Pull Requests</a></h4>
                         <div class="date">Ongoing</div>
                         <div class="excerpt">
                             Review code changes, contributions, and development history through pull requests.
                         </div>
                     </li>
                 </ul>
-            </div>
 
-            <p><strong>Note:</strong> Some documents may require access to the <a href="login.html">private area</a>.</p>
+                <h3>Creative &amp; Fun Documents</h3>
+                <ul>
+                    <li>
+                        <h4><a href="hypermodernity_essay.html">Hypermodernity and Technology: An Essay in Six Chapters</a></h4>
+                        <div class="date">January 2025</div>
+                        <div class="excerpt">
+                            An in-depth essay exploring the intersection of hypermodernity, technology, and contemporary society through six analytical chapters.
+                        </div>
+                    </li>
+                    <li>
+                        <h4><a href="dev-work/hangman-dos.html">MS-DOS Hangman Emulator</a></h4>
+                        <div class="date">April 2025</div>
+                        <div class="excerpt">
+                            Play a nostalgic word-guessing game experience inspired by classic MS-DOS terminals, now available to everyone.
+                        </div>
+                    </li>
+                </ul>
+            </div>
         </section>
     </main>
 

--- a/documents.html
+++ b/documents.html
@@ -72,7 +72,7 @@
                     </li>
                 </ul>
 
-                <h3>Creative &amp; Fun Documents</h3>
+                <h3>Creative and Fun Documents</h3>
                 <ul>
                     <li>
                         <h4><a href="hypermodernity_essay.html">Hypermodernity and Technology: An Essay in Six Chapters</a></h4>

--- a/private.html
+++ b/private.html
@@ -42,14 +42,7 @@
 
             <div class="dev-work-section">
                 <h3>Development Work</h3>
-                <p>Here you can find some of my development projects:</p>
-
-                <ul class="dev-projects">
-                    <li>
-                        <a href="dev-work/hangman-dos.html">MS-DOS Hangman Game</a>
-                        <span class="project-desc">A classic word guessing game implemented in MS-DOS</span>
-                    </li>
-                </ul>
+                <p>Stay tuned for more exclusive development experiments coming soon.</p>
             </div>
 
             <button id="logout-button" type="button" style="margin-top: 20px;" aria-label="Logout from private area">Logout</button>


### PR DESCRIPTION
## Summary
- remove the hangman emulator link from the private area development work list
- reorganize the documents page into meta and creative sections
- add the hangman emulator to the public-facing documents list under creative content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690aa224b4d88321b31c7be49445d314