### PR TITLE
Revamp about page content and navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,6 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="documents.html">Documents</a></li>
-                <li><a href="login.html">Private Area</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
             </ul>
         </nav>
@@ -23,27 +22,26 @@
     <main>
         <section class="about-content">
             <h2>About This Website</h2>
-            <p>Welcome to my first website! This is a simple demonstration of HTML, CSS, and JavaScript working together.</p>
+            <p>This site started as a playground for learning the absolute basics of the web stack and has grown into a living archive of experiments, prototypes, and notes from the journey.</p>
 
-            <h3>Technologies Used</h3>
+            <h3>Development Story</h3>
+            <p>The project kicked off with static HTML pages that documented each small breakthrough. As new ideas surfaced, the site absorbed them: stylesheets were refactored, JavaScript utilities were shared across pages, and an embedded React sandbox was introduced to document modern component explorations. Every branch of the repository doubles as documentation of what was tried, why it mattered, and what was left behind for future reflection.</p>
+
+            <h3>Documentation &amp; Resources</h3>
             <ul>
-                <li>HTML5 for structure</li>
-                <li>CSS3 for styling</li>
-                <li>JavaScript for interactivity</li>
-                <li>React for modern components</li>
+                <li>Project source, issues, and dev logs live in the <a href="https://github.com/idealase/idealase.github.io" target="_blank" rel="noopener">GitHub repository</a>.</li>
+                <li>Historical context for the "First JS" prototype, including notes on the original vanilla JavaScript widgets, resides in <a href="documents.html">the documents section</a>.</li>
+                <li>Experiments with authentication, security headers, and testing are captured across the <code>tests/</code> folder and the linked reports.</li>
             </ul>
 
-            <h3>Features</h3>
+            <h3>What You Can Explore</h3>
             <ul>
-                <li>Responsive design</li>
-                <li>Dark theme</li>
-                <li>Private area with authentication</li>
-                <li>Interactive visualizations</li>
-                <li>Contact form</li>
+                <li>Timeline snapshots of each refactor and technology spike.</li>
+                <li>Comparisons between static and React-driven interfaces.</li>
+                <li>Security hardening notes, accessibility checklists, and lessons learned.</li>
             </ul>
 
-            <h3>Purpose</h3>
-            <p>This website serves as a learning project and demonstration of web development fundamentals. It includes both static HTML pages and a modern React application.</p>
+            <p class="whisper">Psst... the backstage <a href="login.html">portal</a> is tucked away right here for those who know to look.</p>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- rewrite the about page content to highlight the site's development history and documentation resources
- remove the private area link from the main navigation and add a discreet link within the about page content
- update repository references to point to the active GitHub project and remove outdated sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ab4fc58dc832181e55fbba7c0c0d8