### PR TITLE
Add Bucket Flow Calculus simulator page

### DIFF
--- a/react-website/public/index.html
+++ b/react-website/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/react-website/src/App.tsx
+++ b/react-website/src/App.tsx
@@ -9,6 +9,7 @@ import DevelopmentPage from './components/DevelopmentPage';
 import LoginPage from './components/LoginPage';
 import PerthBeerCuratorPage from './components/PerthBeerCuratorPage';
 import ContactPage from './components/ContactPage';
+import BucketFlowPage from './components/BucketFlowPage';
 
 const AppContainer = styled.div`
   min-height: 100vh;
@@ -42,6 +43,7 @@ function App() {
             <Route path="/development" element={<DevelopmentPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/perth-beer-curator" element={<PerthBeerCuratorPage />} />
+            <Route path="/bucket-flow" element={<BucketFlowPage />} />
             <Route path="/contact" element={<ContactPage />} />
           </Routes>
         </MainContent>

--- a/react-website/src/components/BucketFlowPage.tsx
+++ b/react-website/src/components/BucketFlowPage.tsx
@@ -1,0 +1,499 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import BucketViz from './bucketflow/BucketViz';
+import FlowCharts from './bucketflow/FlowCharts';
+import { useBucketSimulation } from './bucketflow/useBucketSimulation';
+import type { BucketParams, InflowPattern, OutflowLaw } from './bucketflow/types';
+
+const PageContainer = styled.div`
+  min-height: 100vh;
+  background: #141414;
+  padding: 2rem 1.5rem 4rem;
+  color: #e1e1e1;
+`;
+
+const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  @media (min-width: 960px) {
+    grid-template-columns: 1.1fr 1.2fr;
+    align-items: start;
+  }
+`;
+
+const Panel = styled.section`
+  background: rgba(25, 25, 25, 0.85);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+`;
+
+const Title = styled.h2`
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  color: #e1e1e1;
+`;
+
+const Subtitle = styled.p`
+  margin: 0 0 1.5rem;
+  color: #b8b8b8;
+  line-height: 1.5;
+`;
+
+const Equation = styled.div`
+  font-size: 0.95rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(94, 129, 172, 0.12);
+  color: #88c0d0;
+  margin-bottom: 1.5rem;
+`;
+
+const ControlsGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+
+  @media (min-width: 700px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+const ControlGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const LabelRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #b8b8b8;
+`;
+
+const RangeInput = styled.input`
+  width: 100%;
+  accent-color: #88c0d0;
+  height: 24px;
+`;
+
+const Select = styled.select`
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(136, 192, 208, 0.4);
+  background: #1f1f1f;
+  color: #e1e1e1;
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+`;
+
+const Button = styled.button`
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  background: #88c0d0;
+  color: #0e0e0e;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+  }
+`;
+
+const SecondaryButton = styled(Button)`
+  background: rgba(136, 192, 208, 0.25);
+  color: #e1e1e1;
+`;
+
+const ReadoutGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+`;
+
+const ReadoutCard = styled.div`
+  background: rgba(30, 30, 30, 0.75);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+`;
+
+const ReadoutLabel = styled.div`
+  font-size: 0.8rem;
+  color: #b8b8b8;
+`;
+
+const ReadoutValue = styled.div`
+  font-size: 1.1rem;
+  color: #e1e1e1;
+  margin-top: 0.25rem;
+`;
+
+const HelperText = styled.p`
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #9aa0a6;
+`;
+
+const ToggleRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #b8b8b8;
+`;
+
+const defaultParams: BucketParams = {
+  bucketHeight: 0.4,
+  bucketRadius: 0.15,
+  initialHeight: 0.2,
+  inflowPattern: 'constant',
+  inflowRate: 0.002,
+  inflowBase: 0.001,
+  inflowAmplitude: 0.001,
+  inflowPeriod: 8,
+  stepEnabled: true,
+  pulsePeriod: 6,
+  pulseDutyCycle: 0.4,
+  outflowLaw: 'linear',
+  linearOutflowK: 0.01,
+  sqrtOutflowK: 0.002
+};
+
+const BucketFlowPage: React.FC = () => {
+  const [params, setParams] = useState<BucketParams>(defaultParams);
+  const { state, samples, running, start, pause, reset } = useBucketSimulation(params);
+
+  useEffect(() => {
+    document.title = 'Bucket Flow Calculus - sandford.systems';
+  }, []);
+
+  const area = useMemo(() => Math.PI * params.bucketRadius * params.bucketRadius, [params.bucketRadius]);
+
+  const updateParam = <K extends keyof BucketParams>(key: K, value: BucketParams[K]) => {
+    setParams(prev => {
+      const next = { ...prev, [key]: value };
+      if (key === 'bucketHeight') {
+        next.initialHeight = Math.min(next.initialHeight, value as number);
+      }
+      return next;
+    });
+  };
+
+  const formatMeters = (value: number) => value.toFixed(3);
+  const formatFlow = (value: number) => value.toFixed(4);
+
+  const inflowOptions: Array<{ label: string; value: InflowPattern }> = [
+    { label: 'Constant', value: 'constant' },
+    { label: 'Sine', value: 'sine' },
+    { label: 'Step', value: 'step' },
+    { label: 'Pulse train', value: 'pulse' }
+  ];
+
+  const outflowOptions: Array<{ label: string; value: OutflowLaw }> = [
+    { label: 'Linear', value: 'linear' },
+    { label: 'Sqrt (Torricelli)', value: 'sqrt' }
+  ];
+
+  return (
+    <PageContainer>
+      <Title>Bucket Flow Calculus</Title>
+      <Subtitle>
+        Explore how the water height changes in real time. The rate of change is always
+        <strong> inflow − outflow</strong>, scaled by the bucket area.
+      </Subtitle>
+      <Equation>dh/dt = (q_in − q_out − q_spill) / A_bucket</Equation>
+
+      <Layout>
+        <Panel>
+          <BucketViz height={state.height} maxHeight={params.bucketHeight} qOut={state.qOut} />
+          <ReadoutGrid>
+            <ReadoutCard>
+              <ReadoutLabel>Time</ReadoutLabel>
+              <ReadoutValue>{state.simTime.toFixed(1)} s</ReadoutValue>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>Height</ReadoutLabel>
+              <ReadoutValue>{formatMeters(state.height)} m</ReadoutValue>
+              <HelperText>{(state.height * 100).toFixed(1)} cm</HelperText>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>Volume</ReadoutLabel>
+              <ReadoutValue>{(state.volume * 1000).toFixed(1)} L</ReadoutValue>
+              <HelperText>{state.volume.toFixed(4)} m³</HelperText>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>q_in</ReadoutLabel>
+              <ReadoutValue>{formatFlow(state.qIn)} m³/s</ReadoutValue>
+              <HelperText>{(state.qIn * 1000).toFixed(2)} L/s</HelperText>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>q_out</ReadoutLabel>
+              <ReadoutValue>{formatFlow(state.qOut)} m³/s</ReadoutValue>
+              <HelperText>{(state.qOut * 1000).toFixed(2)} L/s</HelperText>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>q_net</ReadoutLabel>
+              <ReadoutValue>{formatFlow(state.qNet)} m³/s</ReadoutValue>
+              <HelperText>{(state.qNet * 1000).toFixed(2)} L/s</HelperText>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>Spill</ReadoutLabel>
+              <ReadoutValue>{formatFlow(state.qSpill)} m³/s</ReadoutValue>
+              <HelperText>{(state.qSpill * 1000).toFixed(2)} L/s</HelperText>
+            </ReadoutCard>
+            <ReadoutCard>
+              <ReadoutLabel>Bucket area</ReadoutLabel>
+              <ReadoutValue>{area.toFixed(3)} m²</ReadoutValue>
+            </ReadoutCard>
+          </ReadoutGrid>
+        </Panel>
+
+        <Panel>
+          <ButtonRow>
+            {running ? (
+              <SecondaryButton onClick={pause} type="button">Pause</SecondaryButton>
+            ) : (
+              <Button onClick={start} type="button">Start</Button>
+            )}
+            <SecondaryButton onClick={reset} type="button">Reset</SecondaryButton>
+          </ButtonRow>
+
+          <ControlsGrid>
+            <ControlGroup>
+              <LabelRow>
+                <span>Bucket height (H_MAX)</span>
+                <span>{formatMeters(params.bucketHeight)} m</span>
+              </LabelRow>
+              <RangeInput
+                type="range"
+                min={0.1}
+                max={1}
+                step={0.01}
+                value={params.bucketHeight}
+                onChange={(event) => updateParam('bucketHeight', Number(event.target.value))}
+              />
+            </ControlGroup>
+            <ControlGroup>
+              <LabelRow>
+                <span>Bucket radius</span>
+                <span>{formatMeters(params.bucketRadius)} m</span>
+              </LabelRow>
+              <RangeInput
+                type="range"
+                min={0.05}
+                max={0.3}
+                step={0.01}
+                value={params.bucketRadius}
+                onChange={(event) => updateParam('bucketRadius', Number(event.target.value))}
+              />
+            </ControlGroup>
+            <ControlGroup>
+              <LabelRow>
+                <span>Initial height h₀</span>
+                <span>{formatMeters(params.initialHeight)} m</span>
+              </LabelRow>
+              <RangeInput
+                type="range"
+                min={0}
+                max={params.bucketHeight}
+                step={0.01}
+                value={params.initialHeight}
+                onChange={(event) => updateParam('initialHeight', Number(event.target.value))}
+              />
+            </ControlGroup>
+            <ControlGroup>
+              <LabelRow>
+                <span>Outflow law</span>
+              </LabelRow>
+              <Select
+                value={params.outflowLaw}
+                onChange={(event) => updateParam('outflowLaw', event.target.value as OutflowLaw)}
+              >
+                {outflowOptions.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </Select>
+            </ControlGroup>
+            {params.outflowLaw === 'linear' ? (
+              <ControlGroup>
+                <LabelRow>
+                  <span>Linear k</span>
+                  <span>{params.linearOutflowK.toFixed(3)}</span>
+                </LabelRow>
+                <RangeInput
+                  type="range"
+                  min={0}
+                  max={0.1}
+                  step={0.001}
+                  value={params.linearOutflowK}
+                  onChange={(event) => updateParam('linearOutflowK', Number(event.target.value))}
+                />
+                <HelperText>q_out = k · h (m³/s)</HelperText>
+              </ControlGroup>
+            ) : (
+              <ControlGroup>
+                <LabelRow>
+                  <span>Hole constant (sqrt law)</span>
+                  <span>{params.sqrtOutflowK.toFixed(3)}</span>
+                </LabelRow>
+                <RangeInput
+                  type="range"
+                  min={0}
+                  max={0.02}
+                  step={0.0005}
+                  value={params.sqrtOutflowK}
+                  onChange={(event) => updateParam('sqrtOutflowK', Number(event.target.value))}
+                />
+                <HelperText>q_out = k · √h (m³/s)</HelperText>
+              </ControlGroup>
+            )}
+            <ControlGroup>
+              <LabelRow>
+                <span>Inflow pattern</span>
+              </LabelRow>
+              <Select
+                value={params.inflowPattern}
+                onChange={(event) => updateParam('inflowPattern', event.target.value as InflowPattern)}
+              >
+                {inflowOptions.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </Select>
+            </ControlGroup>
+
+            {(params.inflowPattern === 'constant' || params.inflowPattern === 'step' || params.inflowPattern === 'pulse') && (
+              <ControlGroup>
+                <LabelRow>
+                  <span>Inflow rate</span>
+                  <span>{formatFlow(params.inflowRate)} m³/s</span>
+                </LabelRow>
+                <RangeInput
+                  type="range"
+                  min={0}
+                  max={0.01}
+                  step={0.0002}
+                  value={params.inflowRate}
+                  onChange={(event) => updateParam('inflowRate', Number(event.target.value))}
+                />
+              </ControlGroup>
+            )}
+
+            {params.inflowPattern === 'sine' && (
+              <>
+                <ControlGroup>
+                  <LabelRow>
+                    <span>Base inflow</span>
+                    <span>{formatFlow(params.inflowBase)} m³/s</span>
+                  </LabelRow>
+                  <RangeInput
+                    type="range"
+                    min={0}
+                    max={0.008}
+                    step={0.0002}
+                    value={params.inflowBase}
+                    onChange={(event) => updateParam('inflowBase', Number(event.target.value))}
+                  />
+                </ControlGroup>
+                <ControlGroup>
+                  <LabelRow>
+                    <span>Amplitude</span>
+                    <span>{formatFlow(params.inflowAmplitude)} m³/s</span>
+                  </LabelRow>
+                  <RangeInput
+                    type="range"
+                    min={0}
+                    max={0.008}
+                    step={0.0002}
+                    value={params.inflowAmplitude}
+                    onChange={(event) => updateParam('inflowAmplitude', Number(event.target.value))}
+                  />
+                </ControlGroup>
+                <ControlGroup>
+                  <LabelRow>
+                    <span>Period</span>
+                    <span>{params.inflowPeriod.toFixed(1)} s</span>
+                  </LabelRow>
+                  <RangeInput
+                    type="range"
+                    min={2}
+                    max={20}
+                    step={0.5}
+                    value={params.inflowPeriod}
+                    onChange={(event) => updateParam('inflowPeriod', Number(event.target.value))}
+                  />
+                </ControlGroup>
+              </>
+            )}
+
+            {params.inflowPattern === 'step' && (
+              <ControlGroup>
+                <ToggleRow>
+                  <input
+                    type="checkbox"
+                    checked={params.stepEnabled}
+                    onChange={(event) => updateParam('stepEnabled', event.target.checked)}
+                  />
+                  Step on/off
+                </ToggleRow>
+                <HelperText>Toggle inflow on/off instantly.</HelperText>
+              </ControlGroup>
+            )}
+
+            {params.inflowPattern === 'pulse' && (
+              <>
+                <ControlGroup>
+                  <LabelRow>
+                    <span>Pulse period</span>
+                    <span>{params.pulsePeriod.toFixed(1)} s</span>
+                  </LabelRow>
+                  <RangeInput
+                    type="range"
+                    min={1}
+                    max={20}
+                    step={0.5}
+                    value={params.pulsePeriod}
+                    onChange={(event) => updateParam('pulsePeriod', Number(event.target.value))}
+                  />
+                </ControlGroup>
+                <ControlGroup>
+                  <LabelRow>
+                    <span>Duty cycle</span>
+                    <span>{(params.pulseDutyCycle * 100).toFixed(0)}%</span>
+                  </LabelRow>
+                  <RangeInput
+                    type="range"
+                    min={0.1}
+                    max={0.9}
+                    step={0.05}
+                    value={params.pulseDutyCycle}
+                    onChange={(event) => updateParam('pulseDutyCycle', Number(event.target.value))}
+                  />
+                </ControlGroup>
+              </>
+            )}
+          </ControlsGrid>
+          <HelperText>
+            Adjust sliders while running. The simulator integrates at a fixed time step and clamps
+            height between 0 and H_MAX to avoid numerical blow-up.
+          </HelperText>
+        </Panel>
+      </Layout>
+
+      <FlowCharts samples={samples} maxHeight={params.bucketHeight} />
+    </PageContainer>
+  );
+};
+
+export default BucketFlowPage;

--- a/react-website/src/components/Navigation.tsx
+++ b/react-website/src/components/Navigation.tsx
@@ -169,6 +169,11 @@ const Navigation: React.FC = () => {
           </Link>
         </NavItem>
         <NavItem>
+          <Link to="/bucket-flow" $isActive={location.pathname === '/bucket-flow'}>
+            Bucket Flow
+          </Link>
+        </NavItem>
+        <NavItem>
           <Link to="/login" $isActive={location.pathname === '/login'}>
             Private Area
           </Link>

--- a/react-website/src/components/bucketflow/BucketViz.tsx
+++ b/react-website/src/components/bucketflow/BucketViz.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface BucketVizProps {
+  height: number;
+  maxHeight: number;
+  qOut: number;
+}
+
+const VizWrapper = styled.div`
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+`;
+
+const Svg = styled.svg`
+  width: 100%;
+  height: auto;
+  display: block;
+`;
+
+const formatPercent = (value: number) => Math.min(Math.max(value, 0), 1);
+
+const BucketViz: React.FC<BucketVizProps> = ({ height, maxHeight, qOut }) => {
+  const normalized = maxHeight > 0 ? formatPercent(height / maxHeight) : 0;
+  const waterHeight = 180 * normalized;
+  const waterY = 210 - waterHeight;
+  const streamLength = Math.min(50, qOut * 20000);
+
+  return (
+    <VizWrapper>
+      <Svg viewBox="0 0 220 260" role="img" aria-label="Bucket water level visualization">
+        <defs>
+          <clipPath id="bucket-clip">
+            <rect x="50" y="30" width="120" height="180" rx="14" ry="14" />
+          </clipPath>
+        </defs>
+
+        <rect x="50" y="30" width="120" height="180" rx="14" ry="14" fill="none" stroke="#88c0d0" strokeWidth="4" />
+        <rect x="50" y={waterY} width="120" height={waterHeight} fill="#5e81ac" clipPath="url(#bucket-clip)" />
+
+        <circle cx="170" cy="194" r="5" fill="#88c0d0" />
+        <rect x="168" y={200} width="4" height={streamLength} fill="#88c0d0" opacity={qOut > 0 ? 0.9 : 0} />
+
+        <rect x="40" y="20" width="140" height="200" rx="16" ry="16" fill="none" stroke="rgba(136, 192, 208, 0.2)" strokeWidth="8" />
+      </Svg>
+    </VizWrapper>
+  );
+};
+
+export default BucketViz;

--- a/react-website/src/components/bucketflow/FlowCharts.tsx
+++ b/react-website/src/components/bucketflow/FlowCharts.tsx
@@ -1,0 +1,301 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import type { BucketSample } from './types';
+
+interface FlowChartsProps {
+  samples: BucketSample[];
+  maxHeight: number;
+}
+
+interface D3Scale {
+  (value: number): number;
+  domain: (domain: [number, number]) => D3Scale;
+  range: (range: [number, number]) => D3Scale;
+  nice: () => D3Scale;
+  ticks: (count?: number) => number[];
+}
+
+interface D3Line<T> {
+  x: (fn: (value: T) => number) => D3Line<T>;
+  y: (fn: (value: T) => number) => D3Line<T>;
+  curve: (curve: unknown) => D3Line<T>;
+  (data: T[]): string | null;
+}
+
+interface D3API {
+  scaleLinear: () => D3Scale;
+  line: <T>() => D3Line<T>;
+  curveMonotoneX: unknown;
+}
+
+interface D3Window extends Window {
+  d3?: D3API;
+}
+
+const ChartSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const ChartCard = styled.div`
+  background: rgba(30, 30, 30, 0.7);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+`;
+
+const ChartTitle = styled.h3`
+  margin: 0 0 0.5rem;
+  color: #e1e1e1;
+  font-size: 1.1rem;
+`;
+
+const Svg = styled.svg`
+  width: 100%;
+  height: auto;
+  display: block;
+`;
+
+const Legend = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #b8b8b8;
+`;
+
+const LegendItem = styled.span<{ $color: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+
+  &::before {
+    content: '';
+    width: 12px;
+    height: 3px;
+    border-radius: 2px;
+    background: ${props => props.$color};
+    display: inline-block;
+  }
+`;
+
+const AxisLabel = styled.text`
+  fill: #b8b8b8;
+  font-size: 0.7rem;
+`;
+
+const FallbackText = styled.p`
+  margin: 0.5rem 0 0;
+  color: #b8b8b8;
+  font-size: 0.85rem;
+`;
+
+const useChartSize = () => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState({ width: 320, height: 200 });
+
+  useEffect(() => {
+    if (!ref.current) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setSize({
+          width: Math.max(240, entry.contentRect.width),
+          height: Math.max(160, entry.contentRect.height)
+        });
+      }
+    });
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, size };
+};
+
+const FlowCharts: React.FC<FlowChartsProps> = ({ samples, maxHeight }) => {
+  const d3 = (window as D3Window).d3;
+  const heightChart = useChartSize();
+  const flowChart = useChartSize();
+
+  const timeDomain = useMemo<[number, number]>(() => {
+    if (samples.length === 0) {
+      return [0, 10];
+    }
+    const start = samples[0].t;
+    const end = samples[samples.length - 1].t;
+    return [start, Math.max(start + 1, end)];
+  }, [samples]);
+
+  const heightDomain = useMemo<[number, number]>(() => [0, Math.max(maxHeight, 0.01)], [maxHeight]);
+
+  const flowDomain = useMemo<[number, number]>(() => {
+    if (samples.length === 0) {
+      return [-0.005, 0.005];
+    }
+    let min = 0;
+    let max = 0;
+    samples.forEach(sample => {
+      min = Math.min(min, sample.qNet);
+      max = Math.max(max, sample.qIn, sample.qOut, sample.qNet, sample.qSpill);
+    });
+    if (Math.abs(max - min) < 1e-6) {
+      max = min + 0.001;
+    }
+    return [min, max];
+  }, [samples]);
+
+  const renderChart = useCallback((
+    width: number,
+    height: number,
+    lines: Array<{ path: string; color: string }>,
+    xScale: D3Scale,
+    yScale: D3Scale,
+    xTicks: number[],
+    yTicks: number[]
+  ) => {
+    const padding = { top: 10, right: 12, bottom: 26, left: 44 };
+    const chartWidth = width - padding.left - padding.right;
+    const chartHeight = height - padding.top - padding.bottom;
+
+    const gridLines = yTicks.map((tick) => (
+      <line
+        key={`y-grid-${tick}`}
+        x1={padding.left}
+        x2={padding.left + chartWidth}
+        y1={yScale(tick)}
+        y2={yScale(tick)}
+        stroke="rgba(255,255,255,0.08)"
+      />
+    ));
+
+    return (
+      <Svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+        <g>{gridLines}</g>
+        {lines.map(line => (
+          <path key={line.color} d={line.path} fill="none" stroke={line.color} strokeWidth="2" />
+        ))}
+        {xTicks.map((tick) => (
+          <g key={`x-${tick}`}>
+            <line
+              x1={xScale(tick)}
+              x2={xScale(tick)}
+              y1={padding.top + chartHeight}
+              y2={padding.top + chartHeight + 4}
+              stroke="#666"
+            />
+            <AxisLabel x={xScale(tick)} y={padding.top + chartHeight + 16} textAnchor="middle">
+              {tick.toFixed(0)}s
+            </AxisLabel>
+          </g>
+        ))}
+        {yTicks.map((tick) => (
+          <g key={`y-${tick}`}>
+            <line
+              x1={padding.left - 4}
+              x2={padding.left}
+              y1={yScale(tick)}
+              y2={yScale(tick)}
+              stroke="#666"
+            />
+            <AxisLabel x={padding.left - 8} y={yScale(tick) + 3} textAnchor="end">
+              {tick.toFixed(3)}
+            </AxisLabel>
+          </g>
+        ))}
+      </Svg>
+    );
+  }, []);
+
+  const heightChartContent = useMemo(() => {
+    if (!d3) {
+      return <FallbackText>D3 is not available yet.</FallbackText>;
+    }
+    const width = heightChart.size.width;
+    const height = 200;
+    const padding = { top: 10, right: 12, bottom: 26, left: 44 };
+    const chartWidth = width - padding.left - padding.right;
+    const chartHeight = height - padding.top - padding.bottom;
+
+    const xScale = d3.scaleLinear().domain(timeDomain).range([padding.left, padding.left + chartWidth]);
+    const yScale = d3.scaleLinear().domain(heightDomain).range([padding.top + chartHeight, padding.top]).nice();
+
+    const line = d3.line<BucketSample>()
+      .x((d) => xScale(d.t))
+      .y((d) => yScale(d.h))
+      .curve(d3.curveMonotoneX);
+
+    const path = samples.length > 1 ? line(samples) ?? '' : '';
+    const xTicks = xScale.ticks(5);
+    const yTicks = yScale.ticks(4);
+    return renderChart(width, height, [{ path, color: '#88c0d0' }], xScale, yScale, xTicks, yTicks);
+  }, [d3, heightChart.size.width, heightDomain, renderChart, samples, timeDomain]);
+
+  const flowChartContent = useMemo(() => {
+    if (!d3) {
+      return <FallbackText>D3 is not available yet.</FallbackText>;
+    }
+    const width = flowChart.size.width;
+    const height = 220;
+    const padding = { top: 10, right: 12, bottom: 26, left: 44 };
+    const chartWidth = width - padding.left - padding.right;
+    const chartHeight = height - padding.top - padding.bottom;
+
+    const xScale = d3.scaleLinear().domain(timeDomain).range([padding.left, padding.left + chartWidth]);
+    const yScale = d3.scaleLinear().domain(flowDomain).range([padding.top + chartHeight, padding.top]).nice();
+
+    const line = d3.line<BucketSample>()
+      .x((d) => xScale(d.t))
+      .y((d) => yScale(d.qIn))
+      .curve(d3.curveMonotoneX);
+    const outLine = d3.line<BucketSample>()
+      .x((d) => xScale(d.t))
+      .y((d) => yScale(d.qOut))
+      .curve(d3.curveMonotoneX);
+    const netLine = d3.line<BucketSample>()
+      .x((d) => xScale(d.t))
+      .y((d) => yScale(d.qNet))
+      .curve(d3.curveMonotoneX);
+    const spillLine = d3.line<BucketSample>()
+      .x((d) => xScale(d.t))
+      .y((d) => yScale(d.qSpill))
+      .curve(d3.curveMonotoneX);
+
+    const lines = [
+      { path: samples.length > 1 ? line(samples) ?? '' : '', color: '#a3be8c' },
+      { path: samples.length > 1 ? outLine(samples) ?? '' : '', color: '#bf616a' },
+      { path: samples.length > 1 ? netLine(samples) ?? '' : '', color: '#88c0d0' },
+      { path: samples.length > 1 ? spillLine(samples) ?? '' : '', color: '#ebcb8b' }
+    ];
+    const xTicks = xScale.ticks(5);
+    const yTicks = yScale.ticks(4);
+    return renderChart(width, height, lines, xScale, yScale, xTicks, yTicks);
+  }, [d3, flowChart.size.width, flowDomain, renderChart, samples, timeDomain]);
+
+  return (
+    <ChartSection>
+      <ChartCard ref={heightChart.ref}>
+        <ChartTitle>Height vs time</ChartTitle>
+        {heightChartContent}
+        <Legend>
+          <LegendItem $color="#88c0d0">h(t) [m]</LegendItem>
+        </Legend>
+      </ChartCard>
+      <ChartCard ref={flowChart.ref}>
+        <ChartTitle>Flows vs time</ChartTitle>
+        {flowChartContent}
+        <Legend>
+          <LegendItem $color="#a3be8c">q_in</LegendItem>
+          <LegendItem $color="#bf616a">q_out</LegendItem>
+          <LegendItem $color="#88c0d0">q_net</LegendItem>
+          <LegendItem $color="#ebcb8b">q_spill</LegendItem>
+        </Legend>
+      </ChartCard>
+    </ChartSection>
+  );
+};
+
+export default FlowCharts;

--- a/react-website/src/components/bucketflow/types.ts
+++ b/react-website/src/components/bucketflow/types.ts
@@ -1,0 +1,47 @@
+export type OutflowLaw = 'linear' | 'sqrt';
+export type InflowPattern = 'constant' | 'sine' | 'step' | 'pulse';
+
+export interface BucketParams {
+  bucketHeight: number;
+  bucketRadius: number;
+  initialHeight: number;
+  inflowPattern: InflowPattern;
+  inflowRate: number;
+  inflowBase: number;
+  inflowAmplitude: number;
+  inflowPeriod: number;
+  stepEnabled: boolean;
+  pulsePeriod: number;
+  pulseDutyCycle: number;
+  outflowLaw: OutflowLaw;
+  linearOutflowK: number;
+  sqrtOutflowK: number;
+}
+
+export interface BucketSample {
+  t: number;
+  h: number;
+  qIn: number;
+  qOut: number;
+  qNet: number;
+  qSpill: number;
+}
+
+export interface BucketState {
+  simTime: number;
+  height: number;
+  volume: number;
+  qIn: number;
+  qOut: number;
+  qNet: number;
+  qSpill: number;
+}
+
+export interface BucketSimulation {
+  state: BucketState;
+  samples: BucketSample[];
+  running: boolean;
+  start: () => void;
+  pause: () => void;
+  reset: () => void;
+}

--- a/react-website/src/components/bucketflow/useBucketSimulation.ts
+++ b/react-website/src/components/bucketflow/useBucketSimulation.ts
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { BucketParams, BucketSample, BucketSimulation, BucketState } from './types';
+
+const FIXED_DT = 1 / 120;
+const MAX_FRAME_DT = 0.1;
+const SAMPLE_STRIDE = 4;
+const WINDOW_SECONDS = 60;
+const PUBLISH_INTERVAL = 1 / 30;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const computeBucketArea = (radius: number) => Math.max(Math.PI * radius * radius, 1e-6);
+
+const computeInflow = (t: number, params: BucketParams) => {
+  switch (params.inflowPattern) {
+    case 'constant':
+      return Math.max(params.inflowRate, 0);
+    case 'step':
+      return params.stepEnabled ? Math.max(params.inflowRate, 0) : 0;
+    case 'sine': {
+      const omega = (2 * Math.PI) / Math.max(params.inflowPeriod, 0.1);
+      const base = Math.max(params.inflowBase, 0);
+      const amplitude = Math.max(params.inflowAmplitude, 0);
+      return Math.max(0, base + amplitude * Math.sin(omega * t));
+    }
+    case 'pulse': {
+      const period = Math.max(params.pulsePeriod, 0.1);
+      const phase = t % period;
+      const onWindow = period * clamp(params.pulseDutyCycle, 0, 1);
+      return phase < onWindow ? Math.max(params.inflowRate, 0) : 0;
+    }
+    default:
+      return 0;
+  }
+};
+
+const computeOutflow = (height: number, params: BucketParams) => {
+  const safeHeight = Math.max(height, 0);
+  if (params.outflowLaw === 'linear') {
+    return Math.max(params.linearOutflowK, 0) * safeHeight;
+  }
+  return Math.max(params.sqrtOutflowK, 0) * Math.sqrt(safeHeight);
+};
+
+export const useBucketSimulation = (params: BucketParams): BucketSimulation => {
+  const [running, setRunning] = useState(false);
+  const [state, setState] = useState<BucketState>(() => {
+    const area = computeBucketArea(params.bucketRadius);
+    const height = clamp(params.initialHeight, 0, params.bucketHeight);
+    return {
+      simTime: 0,
+      height,
+      volume: height * area,
+      qIn: 0,
+      qOut: 0,
+      qNet: 0,
+      qSpill: 0
+    };
+  });
+  const [samples, setSamples] = useState<BucketSample[]>([]);
+
+  const runningRef = useRef(running);
+  const paramsRef = useRef(params);
+  const areaRef = useRef(computeBucketArea(params.bucketRadius));
+  const heightRef = useRef(state.height);
+  const timeRef = useRef(state.simTime);
+  const accumulatorRef = useRef(0);
+  const lastFrameRef = useRef<number | null>(null);
+  const sampleBufferRef = useRef<BucketSample[]>([]);
+  const stepCountRef = useRef(0);
+  const lastPublishRef = useRef(0);
+
+  const area = useMemo(() => computeBucketArea(params.bucketRadius), [params.bucketRadius]);
+
+  useEffect(() => {
+    runningRef.current = running;
+  }, [running]);
+
+  useEffect(() => {
+    paramsRef.current = params;
+  }, [params]);
+
+  useEffect(() => {
+    areaRef.current = computeBucketArea(params.bucketRadius);
+  }, [params.bucketRadius]);
+
+  useEffect(() => {
+    const clampedHeight = clamp(heightRef.current, 0, params.bucketHeight);
+    heightRef.current = clampedHeight;
+    setState((prev) => ({
+      ...prev,
+      height: clampedHeight,
+      volume: clampedHeight * area
+    }));
+  }, [params.bucketHeight, area]);
+
+  const pushSample = useCallback(
+    (sample: BucketSample) => {
+      sampleBufferRef.current.push(sample);
+      const cutoff = sample.t - WINDOW_SECONDS;
+      while (sampleBufferRef.current.length > 0 && sampleBufferRef.current[0].t < cutoff) {
+        sampleBufferRef.current.shift();
+      }
+    },
+    []
+  );
+
+  const integrateStep = useCallback(() => {
+    const currentParams = paramsRef.current;
+    const safeHeight = clamp(heightRef.current, 0, currentParams.bucketHeight);
+    const qIn = computeInflow(timeRef.current, currentParams);
+    const qOut = computeOutflow(safeHeight, currentParams);
+    let qSpill = 0;
+    if (safeHeight >= currentParams.bucketHeight - 1e-6) {
+      const net = qIn - qOut;
+      if (net > 0) {
+        qSpill = net;
+      }
+    }
+    const dh = FIXED_DT * (qIn - qOut - qSpill) / areaRef.current;
+    const nextHeight = clamp(safeHeight + dh, 0, currentParams.bucketHeight);
+
+    heightRef.current = nextHeight;
+    timeRef.current += FIXED_DT;
+    stepCountRef.current += 1;
+
+    if (stepCountRef.current % SAMPLE_STRIDE === 0) {
+      const qNet = qIn - qOut - qSpill;
+      pushSample({
+        t: timeRef.current,
+        h: nextHeight,
+        qIn,
+        qOut,
+        qNet,
+        qSpill
+      });
+    }
+  }, [pushSample]);
+
+  const animate = useCallback(
+    (timestamp: number) => {
+      if (!runningRef.current) {
+        lastFrameRef.current = null;
+        return;
+      }
+      if (lastFrameRef.current === null) {
+        lastFrameRef.current = timestamp;
+      }
+      const dt = Math.min((timestamp - lastFrameRef.current) / 1000, MAX_FRAME_DT);
+      lastFrameRef.current = timestamp;
+      accumulatorRef.current += dt;
+
+      while (accumulatorRef.current >= FIXED_DT) {
+        integrateStep();
+        accumulatorRef.current -= FIXED_DT;
+      }
+
+      const shouldPublish = timeRef.current - lastPublishRef.current >= PUBLISH_INTERVAL;
+      if (shouldPublish) {
+        const currentParams = paramsRef.current;
+        const qIn = computeInflow(timeRef.current, currentParams);
+        const qOut = computeOutflow(heightRef.current, currentParams);
+        const qSpill = heightRef.current >= currentParams.bucketHeight - 1e-6 ? Math.max(qIn - qOut, 0) : 0;
+        const qNet = qIn - qOut - qSpill;
+        lastPublishRef.current = timeRef.current;
+        setState({
+          simTime: timeRef.current,
+          height: heightRef.current,
+          volume: heightRef.current * areaRef.current,
+          qIn,
+          qOut,
+          qNet,
+          qSpill
+        });
+        setSamples([...sampleBufferRef.current]);
+      }
+
+      requestAnimationFrame(animate);
+    },
+    [integrateStep]
+  );
+
+  useEffect(() => {
+    if (!running) {
+      return undefined;
+    }
+    const handle = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(handle);
+  }, [animate, running]);
+
+  const start = useCallback(() => {
+    if (runningRef.current) {
+      return;
+    }
+    runningRef.current = true;
+    setRunning(true);
+  }, [animate]);
+
+  const pause = useCallback(() => {
+    runningRef.current = false;
+    setRunning(false);
+    lastFrameRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    runningRef.current = false;
+    setRunning(false);
+    accumulatorRef.current = 0;
+    lastFrameRef.current = null;
+    lastPublishRef.current = 0;
+    stepCountRef.current = 0;
+    sampleBufferRef.current = [];
+    timeRef.current = 0;
+    heightRef.current = clamp(params.initialHeight, 0, params.bucketHeight);
+    const currentParams = paramsRef.current;
+    const qIn = computeInflow(0, currentParams);
+    const qOut = computeOutflow(heightRef.current, currentParams);
+    const qSpill = heightRef.current >= currentParams.bucketHeight - 1e-6 ? Math.max(qIn - qOut, 0) : 0;
+    const qNet = qIn - qOut - qSpill;
+    setState({
+      simTime: 0,
+      height: heightRef.current,
+      volume: heightRef.current * areaRef.current,
+      qIn,
+      qOut,
+      qNet,
+      qSpill
+    });
+    setSamples([]);
+  }, []);
+
+  return {
+    state,
+    samples,
+    running,
+    start,
+    pause,
+    reset
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide an interactive, mobile-friendly educational page demonstrating "dh/dt = (inflow − outflow)/A" using the existing React + TypeScript stack.  
- Keep to repo constraints by not adding npm packages and use D3 for charts via a CDN to avoid dependency changes.  
- Deliver a standalone page with visualization, live controls, and real-time integration for pedagogical exploration.  
- Ensure robustness and performance via clamping, fixed-step integration and bounded rolling buffers.

### Description
- Added a new simulator page and components: `src/components/BucketFlowPage.tsx`, `src/components/bucketflow/useBucketSimulation.ts`, `src/components/bucketflow/BucketViz.tsx`, `src/components/bucketflow/FlowCharts.tsx`, and `src/components/bucketflow/types.ts`.  
- Wired routing and navigation by adding the `/bucket-flow` route in `src/App.tsx` and a navigation link in `src/components/Navigation.tsx`.  
- Implemented the physics and runtime in `useBucketSimulation` with a frame-rate-independent loop (requestAnimationFrame + fixed-step accumulator), multiple inflow patterns (constant, sine, step, pulse), two outflow laws (linear and sqrt/Torricelli), spill handling, throttled state publishes, and a rolling sample buffer trimmed to a time window.  
- Rendered an SVG bucket visualization and D3-driven charts (height and flows) with responsive layout and touch-friendly controls, and loaded D3 from a CDN in `public/index.html` to avoid adding npm dependencies.

### Testing
- Attempted to start the dev server with `npm start`, but the dev server failed to launch due to a `react-scripts` dev-server option mismatch (`onAfterSetupMiddleware`), so manual/visual verification could not be completed.  
- Attempted to capture a browser screenshot with Playwright, but the page was unreachable because the dev server did not start.  
- No automated unit or integration tests were run as part of this rollout.  
- Changes were committed to the repository (files added and route/nav updated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953251734148321893f6d52439c5bcd)